### PR TITLE
Fix discord ID search

### DIFF
--- a/lib/services/tetrio_crud.dart
+++ b/lib/services/tetrio_crud.dart
@@ -1154,7 +1154,7 @@ class TetrioService extends DB {
       if (kIsWeb) {
         dUrl = Uri.https('ts.dan63.by', 'oskware_bridge.php', {"endpoint": "tetrioUserByDiscordID", "user": user.toLowerCase().trim()});
       } else {
-        dUrl = Uri.https('ch.tetr.io', 'api/users/search/${user.toLowerCase().trim()}');
+        dUrl = Uri.https('ch.tetr.io', 'api/users/search/discord:${user.toLowerCase().trim()}');
       }
       try{
         final response = await client.get(dUrl);


### PR DESCRIPTION
Changes:
Change API route to fit the new API specs, indeed one must now specify `discord:` in the URL of /api/users/search to specify it's a discord ID, probably preparing for search with other API's?
